### PR TITLE
Get latest Nuget version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ mono:
 solution: Square.Connect.sln
 
 install:
-  - wget -nc https://nuget.org/nuget.exe;
+  - wget -nc https://dist.nuget.org/win-x86-commandline/latest/nuget.exe;
   - openssl aes-256-cbc -K $encrypted_71f1b33fe68c_key -iv $encrypted_71f1b33fe68c_iv -in ./travis-ci/accounts.enc -out ./travis-ci/accounts.json -d
 
 script:


### PR DESCRIPTION
Since the SDK is autogenerated, these changes will be overwritten on the next release. You'll need to update the templates instead.